### PR TITLE
Use gql-fork 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev" # 3.7 development branch
 # command to install dependencies
 install: "pip install -r requirements.txt"
 before_script: "flake8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/graphql-python/gql.git
+gql-fork==0.2.0
 requests==2.13.0
 flake8==3.5.0
 flake8-config-yoctol==0.0.9

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author="cph",
     packages=find_packages(),
     install_requires=[
-        'gql==0.1.0',
+        'gql-fork==0.2.0',
         'requests==2.13.0',
         'flake8==3.5.0',
         'flake8-config-yoctol==0.0.9',


### PR DESCRIPTION
- Use the [fork version of gql](https://github.com/Yoctol/gql-fork) which has the `RequestsHTTPTransport` functionality
- skip python 3.7 when CI