### PR TITLE
do not sort prediction result

### DIFF
--- a/ynlu/sdk/model.py
+++ b/ynlu/sdk/model.py
@@ -76,11 +76,6 @@ class Model(object):
             }
             for ans in intents_prediction
         ]
-        intents_prediction = sorted(
-            intents_prediction,
-            key=lambda x: x['score'],
-            reverse=True,
-        )
 
         entities_prediction = result['predict']['entities']
         entities_prediction = [
@@ -91,11 +86,6 @@ class Model(object):
             }
             for ans in entities_prediction
         ]
-        entities_prediction = sorted(
-            entities_prediction,
-            key=lambda x: x['score'],
-            reverse=True,
-        )
 
         return intents_prediction, entities_prediction
 

--- a/ynlu/sdk/test/test_model.py
+++ b/ynlu/sdk/test/test_model.py
@@ -7,12 +7,12 @@ FAKE_QUERY = {
     'predict': {
         'intents': [
             {
-                'name': '測試1',
-                'score': 0.17,
-            },
-            {
                 'name': '測試2',
                 'score': 0.78,
+            },
+            {
+                'name': '測試1',
+                'score': 0.17,
             },
         ],
         'entities': [


### PR DESCRIPTION
- Intent does not need sorting since the original result is already sorted
- The entity order has its meaning, which is the appearance order in the original utterance. Purely sorting by score is not only unnecessary  but confusing.