### PR TITLE
centralize management of font style

### DIFF
--- a/docs/reference/ynlu.sdk.evaluation.plot.rst
+++ b/docs/reference/ynlu.sdk.evaluation.plot.rst
@@ -27,6 +27,14 @@ ynlu.sdk.evaluation.plot.line\_plot module
     :undoc-members:
     :show-inheritance:
 
+ynlu.sdk.evaluation.plot.utils module
+-------------------------------------
+
+.. automodule:: ynlu.sdk.evaluation.plot.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/ynlu/sdk/evaluation/plot/confusion_matrix_plot.py
+++ b/ynlu/sdk/evaluation/plot/confusion_matrix_plot.py
@@ -55,16 +55,16 @@ def plot_confusion_matrix(
             If it is None, the figure will be shown on screen
             automatically.
         title (string, default = "Confusion Matrix"):
-            The title of figure.
+            The title of the figure.
         figure_size (a pair of integers, default = (8, 6)):
             The height and width of the output figure.
         cmap (color map):
-            Matplotlib builtin colormaps.
+            Matplotlib built-in colormaps.
         font_style_path (path of font style):
             If None, ``simhei.ttf`` will be used as default font style.
-            Chinese charactors are supported in this font style.
+            Chinese characters are supported in this font style.
         block (bool):
-            if False, the figure will not be shown up even if output_path
+            If False, the figure will not be shown up even if output_path
             is None. This argument is left for unittest.
 
     Returns: None

--- a/ynlu/sdk/evaluation/plot/confusion_matrix_plot.py
+++ b/ynlu/sdk/evaluation/plot/confusion_matrix_plot.py
@@ -1,15 +1,10 @@
 import itertools
 from typing import List, Tuple
-from os.path import join, dirname, abspath
 
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib.font_manager as fm
 
-
-ROOT_DIR = dirname(dirname(abspath(__file__)))
-FONT_PATH = join(ROOT_DIR, "data/simhei.ttf")
-DEFAULT_FONT = fm.FontProperties(fname=FONT_PATH)
+from .utils import plt_set_font_style
 
 
 def _check_input_data_format(
@@ -37,7 +32,7 @@ def plot_confusion_matrix(
         title: str = "Confusion Matrix",
         figure_size: Tuple[int, int] = (8, 6),
         cmap: plt.cm = plt.cm.Blues,
-        font: fm.FontProperties = DEFAULT_FONT,
+        font_style_path: str = None,
         block: bool = True,
     ) -> None:
     """Plot confusion matrix
@@ -65,8 +60,9 @@ def plot_confusion_matrix(
             The height and width of the output figure.
         cmap (color map):
             Matplotlib builtin colormaps.
-        font (font properties):
-            Matplotlib font properties.
+        font_style_path (path of font style):
+            If None, ``simhei.ttf`` will be used as default font style.
+            Chinese charactors are supported in this font style.
         block (bool):
             if False, the figure will not be shown up even if output_path
             is None. This argument is left for unittest.
@@ -100,11 +96,11 @@ def plot_confusion_matrix(
         interpolation='nearest',
         cmap=cmap,
     )
-    plt.title(title, fontproperties=font)
+    plt.title(title)
     plt.colorbar()
     tick_marks = np.arange(len(indices))
-    plt.xticks(tick_marks, indices, rotation=45, fontproperties=font)
-    plt.yticks(tick_marks, indices, fontproperties=font)
+    plt.xticks(tick_marks, indices, rotation=45)
+    plt.yticks(tick_marks, indices)
 
     fmt = '.2f' if normalize else 'd'
     thresh = confusion_matrix.max() / 2.
@@ -119,6 +115,8 @@ def plot_confusion_matrix(
     plt.tight_layout()
     plt.ylabel('True Label')
     plt.xlabel('Predicted Label')
+
+    plt_set_font_style(font_style_path=font_style_path)
 
     if output_path is not None:
         plt.savefig(output_path)

--- a/ynlu/sdk/evaluation/plot/line_plot.py
+++ b/ynlu/sdk/evaluation/plot/line_plot.py
@@ -33,15 +33,15 @@ def plot_lines(
 
     Args:
         data (list of dictionaries):
-            Dictinaries containing arguments and key words for
+            Dictionaries containing arguments and key words for
             ``matplotlib.pyplot.plot``. Basic arguments are:
-            ``x``, ``y``, ``label``(the name of line).
+            ``x``, ``y``, ``label`` (the name of line).
         title (string, default = "figure"):
-            The title of figure.
+            The title of the figure.
         x_axis_name (string, default = "x"):
-            The name shown on x axis.
+            The name to be shown on x axis.
         y_axis_name(string, default = "y"):
-            The name shown on y axis.
+            The name to be shown on y axis.
         figure_size (a pair of integers, default = (8, 6)):
             The height and width of the output figure.
         output_path (string, default = None):
@@ -54,7 +54,7 @@ def plot_lines(
             for more details.
         font_style_path (path of font style):
             If None, ``simhei.ttf`` will be used as default font style.
-            Chinese charactors are supported in this font style.
+            Chinese characters are supported in this font style.
         block (bool):
             if False, the figure will not be shown up even if output_path
             is None. This argument is left for unittest.

--- a/ynlu/sdk/evaluation/plot/line_plot.py
+++ b/ynlu/sdk/evaluation/plot/line_plot.py
@@ -3,6 +3,8 @@ from typing import List, Tuple
 import seaborn as sns
 import matplotlib.pyplot as plt
 
+from .utils import plt_set_font_style
+
 
 def _check_data_format(data: List[dict]):
     for i, datum in enumerate(data):
@@ -23,6 +25,7 @@ def plot_lines(
         figure_size: Tuple[int, int]=(8, 6),
         output_path: str = None,
         color_palette: sns.color_palette = None,
+        font_style_path: str = None,
         block: bool = True,
     ) -> None:
     """Plot y versus x as lines and/or markers
@@ -30,8 +33,9 @@ def plot_lines(
 
     Args:
         data (list of dictionaries):
-            Several dictinaries containing arguments and key words for
-            ``matplotlib.pyplot.plot``
+            Dictinaries containing arguments and key words for
+            ``matplotlib.pyplot.plot``. Basic arguments are:
+            ``x``, ``y``, ``label``(the name of line).
         title (string, default = "figure"):
             The title of figure.
         x_axis_name (string, default = "x"):
@@ -48,6 +52,9 @@ def plot_lines(
             Please take a look at
             ``https://seaborn.pydata.org/generated/seaborn.color_palette.html``
             for more details.
+        font_style_path (path of font style):
+            If None, ``simhei.ttf`` will be used as default font style.
+            Chinese charactors are supported in this font style.
         block (bool):
             if False, the figure will not be shown up even if output_path
             is None. This argument is left for unittest.
@@ -99,6 +106,9 @@ def plot_lines(
         loc=2,
         borderaxespad=0.,
     )
+    plt.subplots_adjust(right=0.8)
+    plt_set_font_style(font_style_path=font_style_path)
+
     if output_path is not None:
         plt.savefig(output_path)
     else:

--- a/ynlu/sdk/evaluation/plot/test/test_line_plot.py
+++ b/ynlu/sdk/evaluation/plot/test/test_line_plot.py
@@ -18,6 +18,33 @@ class LinePlotTestCase(TestCase):
                 ],
                 "block": False,
             },
+            {
+                "data": [
+                    {
+                        "x": [1, 2, 3],
+                        "y": [4, 5, 6],
+                    },
+                ],
+                "block": False,
+                "x_axis_name": "x軸",
+                "y_axis_name": "y軸",
+                "title": "我是標題",
+            },
+            {
+                "data": [
+                    {
+                        "x": [1, 2, 3],
+                        "y": [4, 5, 6],
+                        "label": "第一條",
+                    },
+                    {
+                        "x": [1, 2, 3],
+                        "y": [-4, -5, -6],
+                        "label": "第二條",
+                    },
+                ],
+                "block": False,
+            },
         ]
         for test_case in test_cases:
             plot_lines(**test_case)

--- a/ynlu/sdk/evaluation/plot/utils.py
+++ b/ynlu/sdk/evaluation/plot/utils.py
@@ -1,0 +1,48 @@
+from os.path import abspath, dirname, join
+
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib import font_manager
+
+
+ROOT_DIR = dirname(dirname(abspath(__file__)))
+DEFAULT_FONT_PATH = join(ROOT_DIR, "data/simhei.ttf")
+
+
+def _get_all_text_objects(obj):
+    '''
+    Get all text objects in a matplotlib Figure
+    Helper for ``plt_set_font_style``
+    '''
+    queue = [obj]
+    all_text = []
+    while queue:
+        currobj = queue.pop(0)
+        if isinstance(currobj, matplotlib.text.Text):
+            all_text.append(currobj)
+        else:
+            queue = queue + currobj.get_children()
+    return all_text
+
+
+def plt_set_font_style(font_style_path: str = None):
+    """Setting font style of figure plotting by matplotlib
+
+        Args:
+            font_style_path (path of font style):
+                If None, ``simhei.ttf`` will be used as default font style.
+
+        Returns: None
+
+    """
+
+    if font_style_path is None:
+        font_style_path = DEFAULT_FONT_PATH
+
+    font_style = font_manager.FontProperties(fname=font_style_path)
+
+    fig = plt.gcf()
+    for textobj in _get_all_text_objects(fig):
+        fontsize = textobj.get_fontsize()
+        textobj.set_fontproperties(font_style)
+        textobj.set_fontsize(fontsize)

--- a/ynlu/sdk/evaluation/plot/utils.py
+++ b/ynlu/sdk/evaluation/plot/utils.py
@@ -28,6 +28,13 @@ def _get_all_text_objects(obj):
 def plt_set_font_style(font_style_path: str = None):
     """Setting font style of figure plotting by matplotlib
 
+        By calling the function `plt_set_font_style()` before saving
+        or showing a figure, the font style "SimHei" will apply to
+        all the text in a figure. This type of font style supports
+        Chinese characters. If you prefer other font styles, just
+        give where it's stored as an input argument to `plt_set_font_style()`,
+        and all the text in the figure will be presented in that style.
+
         Args:
             font_style_path (path of font style):
                 If None, ``simhei.ttf`` will be used as default font style.


### PR DESCRIPTION
By calling the function `plt_set_font_style()` before saving or showing a figure, the font style "SimHei" will apply to all the text in a figure. This type of font style supports Chinese characters. If you prefer other font styles, just give where it's stored as an input argument to `plt_set_font_style()` , and all the text in the figure will be presented in that style.
