### PR TITLE
make README.md can be rendered normally on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "scikit-learn>=0.19.1",
     ],
     long_description=long_description,
+    long_description_content_type='text/markdown',
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Just found that README.md can't be correctly rendered on PyPI.

https://pypi.org/project/yoctol-nlu/

This one-line modification should fix the problem.
Make sure you have these minimum required versions of the respective tools when you want to upload a new version to PyPI:
```
setuptools >= 38.6.0
wheel >= 0.31.0
twine >= 1.11.0
```
For more information, check [this](https://pypi.org/project/yoctol-nlu/).